### PR TITLE
a hypothetical method to shut down secure-logs-configmap-reload

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -14,3 +14,7 @@
     method: GET
     path: /api/processes.killWorkers
     port: 24444
+- target: secure-logs-configmap-reload
+  action:
+    type: exec
+    command: /bin/kill 6

--- a/actions.yml
+++ b/actions.yml
@@ -17,4 +17,4 @@
 - target: secure-logs-configmap-reload
   action:
     type: exec
-    command: /bin/kill 6
+    command: /bin/killall configmap-reload

--- a/ginuudan/__main__.py
+++ b/ginuudan/__main__.py
@@ -36,7 +36,7 @@ def status_change(logger, status, labels, **kwargs):
             logger.info(f"Shutting down {sidecar}")
             action = actions[sidecar]
             if action["type"] == "exec":
-                handler.exec_command(action["command"].split())
+                handler.exec_command(sidecar, action["command"].split())
             elif action["type"] == "portforward":
                 handler.port_forward(action["method"], action["path"], action["port"])
         else:

--- a/ginuudan/kube.py
+++ b/ginuudan/kube.py
@@ -46,7 +46,7 @@ class KubernetesHandler:
     def completed(self):
         return self.app_state == "terminated" and utils.is_completed(self.app_status)
 
-    def exec_command(self, command):
+    def exec_command(self, container, command):
         try:
             self.core_v1.read_namespaced_pod(name=self.name, namespace=self.namespace)
         except ApiException as e:
@@ -57,6 +57,7 @@ class KubernetesHandler:
             self.core_v1.connect_get_namespaced_pod_exec,
             self.name,
             self.namespace,
+            container=container,
             command=command,
             stderr=True,
             stdin=False,

--- a/test_specs/onpremtest.yaml
+++ b/test_specs/onpremtest.yaml
@@ -30,7 +30,7 @@ spec:
             subPath:   "ca-bundle.pem"
             readOnly:  true
       - name: secure-logs-configmap-reload
-        image: jimmidyson/configmap-reload@sha256:befec9f23d2a9da86a298d448cc9140f56a457362a7d9eecddba192db1ab489e
+        image: ghcr.io/nais/configmap-reload/configmap-reload@sha256:3f30687b1200754924484a12124f7be58a55816661d864f6d1bf44e1131b6de6
         args:
           - --volume-dir=/config
           - --webhook-url=http://localhost:24444/api/config.reload


### PR DESCRIPTION
This requires that naiserator uses [nais/configmap-reload](https://github.com/nais/configmap-reload) as `securelogs_configmapReloadImage` instead of [jimmidyson/configmap-reload](https://github.com/jimmidyson/configmap-reload). 

The branch works as a way to demonstrate how it would act with nais/configmap-reload.

Assuming we're at `dev-fss` in namespace `aura`.

1. `k apply -f test_specs/onpremtest.yaml`
2. `poetry run ginuudan`
3. Sit back, relax, and let ginuudan cleanly shut down the sidecars.
4. `k get pods` and see that the `pi` pod's status is Completed, and that no more `pi` pods get spawned.